### PR TITLE
Each comparison job is now handled by a ThreadPool.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Frank Vumbaca <fvumbaca@outlook.com>"]
 image = "0.19.0"
 csv = "1.0.0"
 clap = "2.31.2"
+rayon = "1.0.1"

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ An batch image similarity tool.
 Create a csv that looks like this:
 
 | image1 | image2 |
-|--------|--------|
+|:------:|:------:|
 | img1.png|img2.png|
 
 
 Then pass the file to the tool with an output file:
 ```bash
-simfinder input.csv output.csv
+$ simfinder input.csv output.csv
 ```
 
 And the output file will look something like:
 
-| image1 | image2 | similarity | elapsed |
-|--------|--------|------------|---------|
+| image1 | image2 | similar | elapsed |
+|:------:|:------:|:-------:|:-------:|
 |img1.png|img2.png|0.56|255|
 
 > Similarity is judged by 0.00 being exactly the same and > 0.00 is different.
@@ -39,6 +39,9 @@ $ cargo install
 ```
 to build and install a release version of simfinder.
 
+> **NOTE:** If you do not want to install the binaries, you could `cargo build` from the project root,
+then find the binary under the generated `targets` directory, or simply run a debug copy of the application by replacing `simfinder` with `cargo run --` in the usage guide when in the root directory of the project.
+
 ## Uninstall
 
 When your done with all this tool has to offer, just run:
@@ -50,6 +53,7 @@ $ cargo uninstall simfinder
 - **[Image](https://github.com/PistonDevelopers/image)** - The basic image library developed for and used in Piston
 - **[Csv](https://github.com/BurntSushi/rust-csv)** - A csv parsing library
 - **[Clap](https://github.com/kbknapp/clap-rs)** - Api for building a beautiful cli
+- **[Rayon](https://github.com/rayon-rs/rayon)** - Data parallelism Library
 
 ## Comparison Algorithm
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
     			});
     		}
 
-    		for result in rx.iter().take(num_jobs) { // will wait for all the jobs to complete
+    		for result in rx.iter().take(num_jobs) { // will wait for all the jobs to complete, but handle as soon as a result is received
     			let (result, j) = result;
     			match result {
     				Some((similarity, elapsed)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,35 @@
 extern crate clap;
+extern crate rayon;
 
 mod img_comparer;
 mod io;
 
 use clap::{Arg, App};
+use std::sync::mpsc::channel;
+
+// Default threads to use is 3. I remember reading somewhere this is a safe 
+// number to assume because it is the least number of worker threads allowed 
+// to be run concurrently on the same machine. More threads MIGHT have diminishing
+// returns depending on OS configuration. ITS BEST TO RUN SOME TESTS AND SEE RUNTIME.
+const DEFAULT_THREADPOOL_COUNT: usize = 3;
 
 fn main() {
+	// Parse arguments.
 	let matches = App::new("simvar")
 		.version("1.0")
 		.author("Frank V. <fvumbaca@outlook.com>")
 		.about("Compares similarity of images.")
 		.arg(Arg::with_name("IMG_DIR")
 			.short("i")
-			.long("imgs")
+			.long("img-dir")
 			.value_name("IMG_DIR")
 			.help("Root folder for images referenced in input file.")
+			.takes_value(true))
+		.arg(Arg::with_name("THREAD_COUNT")
+			.short("t")
+			.long("imgs")
+			.value_name("THREAD_COUNT")
+			.help("Number of threads in thread pool.")
 			.takes_value(true))
 		.arg(Arg::with_name("INPUT_CSV")
 			.help("Filename of the input csv listing comparisons to preform.")
@@ -26,10 +41,15 @@ fn main() {
 			.index(2))
 		.get_matches();
 
+	// Passed arguments after parsing and applying defaults and type enforcements
 	let input_filename = matches.value_of("INPUT_CSV").unwrap(); // Is required so safe for unwraping
 	let output_filename = matches.value_of("OUTPUT_CSV").unwrap(); // Also required
 	let img_dir = matches.value_of("IMG_DIR").unwrap_or("./");
-
+	let thread_count : usize = matches.value_of("THREAD_COUNT").unwrap_or(&DEFAULT_THREADPOOL_COUNT.to_string())
+		.parse().unwrap_or_else(|_| {
+			println!("Invalid number of threads!");
+			std::process::exit(1);
+		});
 
     match io::load(input_filename, img_dir) {
     	Ok(jobs) => { // No errors when loading the file
@@ -41,19 +61,39 @@ fn main() {
 		    	return;
 		    }
 
+		    // Spin up the thread pool
+		    let pool = rayon::ThreadPoolBuilder::new().num_threads(thread_count).build().unwrap();
+		    let (tx, rx) = channel();
+
+		    let num_jobs = jobs.len();
+
 		    // Iterate over the jobs and run each.
     		for j in jobs {
-    			match img_comparer::execute_job(&j) {
-
-    				Ok(result) => { // The Job completed successfully
-    					let (similarity, elapsed) = result;
-    					let ok = io::write_results(&mut f, j.get_filename0(), j.get_filename1(), similarity, elapsed);
-    					if ok.is_err() {
-    						println!("There was a problem writing a result to {}", output_filename);
+				let tx = tx.clone();
+    			pool.install(move || {
+    				let result = img_comparer::execute_job(&j);
+    				// Re-wrapping Result to a Option enum for thread safety
+    				match result {
+    					Ok((similarity, elapsed)) => {
+		    				tx.send((Some((similarity, elapsed)), j)).unwrap();
+    					},
+    					Err(_) => {
+    						tx.send((None, j)).unwrap();
     					}
-    				},
+    				}
+    			});
+    		}
 
-    				Err(_) => { // The Job resulted in an error
+    		for result in rx.iter().take(num_jobs) { // will wait for all the jobs to complete
+    			let (result, j) = result;
+    			match result {
+    				Some((similarity, elapsed)) => {
+						let ok = io::write_results(&mut f, j.get_filename0(), j.get_filename1(), similarity, elapsed);
+						if ok.is_err() {
+							println!("There was a problem writing a result to {}", output_filename);
+						}
+    				},
+    				None => {
     					println!("{} could not be completed because one/both of the files do not exist.", j);
     				}
     			}


### PR DESCRIPTION
Now the application uses a ThreadPool with a default thread count of 3 to handle each job.

To control the number of threads, a flag has been added:
```bash
$ simfinder -t input.csv output.csv
```